### PR TITLE
Add locale-aware paths and i18n adjustments

### DIFF
--- a/src/components/change-locale/change-locale.tsx
+++ b/src/components/change-locale/change-locale.tsx
@@ -19,7 +19,9 @@ export const ChangeLocale = component$(({ place }: { place: "mob-menu" | "header
   const config = useSpeakConfig();
   const dn = useDisplayName();
   const getPath = localizePath();
+
   useStylesScoped$(styles);
+
   useOnDocument(
     "keydown",
     $((e: KeyboardEvent) => {
@@ -38,6 +40,7 @@ export const ChangeLocale = component$(({ place }: { place: "mob-menu" | "header
       }
     }),
   );
+
   return (
     <div class="cl_popover" data-place={place}>
       <button
@@ -52,9 +55,7 @@ export const ChangeLocale = component$(({ place }: { place: "mob-menu" | "header
         aria-controls="language-list"
       >
         <span class="cl_btn_m">{dn(locale.lang.slice(0, 2), { type: "language" })}</span>
-        <span class="cl_btn_t">
-          {locale.lang === "uk-UA" ? "Укр" : locale.lang === "it-IT" ? "It" : "Eng"}
-        </span>
+        <span class="cl_btn_t">{locale.lang === "uk-UA" ? "Ukr" : locale.lang === "it-IT" ? "It" : "Eng"}</span>
         <IconArrow />
       </button>
 
@@ -74,7 +75,7 @@ export const ChangeLocale = component$(({ place }: { place: "mob-menu" | "header
             >
               <span>
                 {value.lang === "uk-UA"
-                  ? "Українська"
+                  ? "Ukrainska"
                   : value.lang === "it-IT"
                     ? "Italiano"
                     : "English"}

--- a/src/components/common/logo/logo.tsx
+++ b/src/components/common/logo/logo.tsx
@@ -1,8 +1,8 @@
 import { component$ } from "@builder.io/qwik";
-import LogoSVG from "/public/logo.svg?jsx";
-import "./style.css";
-import { inlineTranslate, localizePath } from "qwik-speak";
 import { Link } from "@builder.io/qwik-city";
+import LogoSVG from "/public/logo.svg?jsx";
+import { inlineTranslate, localizePath, useSpeakLocale } from "qwik-speak";
+import "./style.css";
 
 type Props = {
   place: "footer" | "header";
@@ -11,8 +11,9 @@ type Props = {
 
 export default component$<Props>(props => {
   const t = inlineTranslate();
+  const { lang } = useSpeakLocale();
   const getPath = localizePath();
-  const [homePath] = getPath(["/"]);
+  const homePath = getPath("/", lang);
   return (
     <Link
       href={homePath}

--- a/src/components/common/nav-list/NavList.tsx
+++ b/src/components/common/nav-list/NavList.tsx
@@ -14,25 +14,30 @@ type Props = {
 export default component$<Props>(({ place, onClick }) => {
   const t = inlineTranslate();
   const location = useLocation();
+  const getPath = localizePath();
   useStylesScoped$(styles);
   const currentPath = location.url.pathname;
-
-  const getPath = localizePath();
-
-  const [teamPath] = getPath(["/team/"]);
-  const [faqPath] = getPath(["/faq/"]);
-  const [homePath] = getPath(["/"]);
+  const lang =
+    currentPath === "/uk-UA" || currentPath.startsWith("/uk-UA/")
+      ? "uk-UA"
+      : currentPath === "/it-IT" || currentPath.startsWith("/it-IT/")
+        ? "it-IT"
+        : "en-EU";
+  const tr = (key: string) => t(key, undefined, lang) as string;
+  const teamPath = getPath("/team/", lang);
+  const faqPath = getPath("/faq/", lang);
+  const homePath = getPath("/", lang);
 
   const baseListItems: NavListItem[] = [
-    { link: "services", label: t("navigation.services@@Services"), path: `${homePath}#services` },
+    { link: "services", label: tr("navigation.services@@Services"), path: `${homePath}#services` },
     {
       link: "portfolio",
-      label: t("navigation.portfolio@@Portfolio"),
+      label: tr("navigation.portfolio@@Portfolio"),
       path: `${homePath}#portfolio`,
     },
-    { link: "team", label: t("navigation.team@@Team"), path: teamPath },
-    { link: "about", label: t("navigation.about@@About"), path: `${homePath}#about` },
-    { link: "contact", label: t("navigation.contact@@Contact"), path: `${currentPath}#contact` },
+    { link: "team", label: tr("navigation.team@@Team"), path: teamPath },
+    { link: "about", label: tr("navigation.about@@About"), path: `${homePath}#about` },
+    { link: "contact", label: tr("navigation.contact@@Contact"), path: `${currentPath}#contact` },
     { link: "faq", label: "FAQ", path: faqPath },
   ];
 
@@ -51,12 +56,18 @@ export default component$<Props>(({ place, onClick }) => {
       id="main-navigation"
       data-place={place}
       class="navigation"
-      aria-label={t("navigation.navTitle@@Main navigation")}
+      aria-label={tr("navigation.navTitle@@Main navigation")}
     >
       <ul data-place={place} class="nav_list glass-card">
         {place === "header" && (
           <li id="home-link">
-            <Link href={homePath} aria-label={t("navigation.linkHome@@Link to home page")}>
+            <Link
+              href={homePath}
+              onClick$={() => {
+                console.log(lang);
+              }}
+              aria-label={tr("navigation.linkHome@@Link to home page")}
+            >
               <IconHome class="icon_home" />
             </Link>
           </li>
@@ -66,9 +77,12 @@ export default component$<Props>(({ place, onClick }) => {
             <li key={item.link}>
               <Link
                 href={item.path}
-                aria-label={`${t("navigation.linkLabel@@Link to section")} ${item.label}`}
+                aria-label={`${tr("navigation.linkLabel@@Link to section")} ${item.label}`}
                 class="btn_body"
-                onClick$={onClick}
+                onClick$={() => {
+                  onClick?.();
+                  console.log(lang);
+                }}
               >
                 <span data-place={place} class="page_link">
                   {item.label}{" "}

--- a/src/components/cookies-banner/CookiesBanner.tsx
+++ b/src/components/cookies-banner/CookiesBanner.tsx
@@ -11,7 +11,7 @@ import styles from "./styles.css?inline";
 import { COOKIES_LOCAL_STORAGE, CookiesTypes } from "~/types/cookies.type";
 import { disableAnalitics, loadAnalytics } from "~/utils/loadGoogleAnalitics";
 import { CookiesBannerContext } from "./coocies-banner-context";
-import { inlineTranslate, localizePath } from "qwik-speak";
+import { inlineTranslate, localizePath, useSpeakLocale } from "qwik-speak";
 import { Link } from "@builder.io/qwik-city";
 
 export default component$(() => {
@@ -23,8 +23,9 @@ export default component$(() => {
     requiredCookies: true,
     analyticsCookies: false,
   });
+  const { lang } = useSpeakLocale();
   const getPath = localizePath();
-  const [cookiesPath] = getPath(["/cookies-policy/"]);
+  const cookiesPath = getPath("/cookies-policy/", lang);
   const { isVisible } = useContext(CookiesBannerContext);
 
   useVisibleTask$(() => {

--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -1,22 +1,23 @@
 import { component$, useContext, useStylesScoped$ } from "@builder.io/qwik";
+import { Link } from "@builder.io/qwik-city";
 import Logo from "~/components/common/logo/logo";
-import { inlineTranslate, localizePath } from "qwik-speak";
+import { inlineTranslate, localizePath, useSpeakLocale } from "qwik-speak";
 import styles from "./styles_footer.css?inline";
 import NavList from "~/components/common/nav-list/NavList";
 import FollowUs from "./follow-us/FollowUs";
 import IconCookies from "~/assets/icons/cookies-icon.svg?w=38&h=38&jsx";
-import { Link } from "@builder.io/qwik-city";
 import { CookiesBannerContext } from "~/components/cookies-banner/coocies-banner-context";
 import AnimatedElement from "~/components/common/animated-ball/AnimatedElement";
 
 export default component$(() => {
   const t = inlineTranslate();
+  const { lang } = useSpeakLocale();
+  const getPath = localizePath();
   useStylesScoped$(styles);
   const currentYear = new Date().getFullYear();
-  const getPath = localizePath();
   const cookiesBanner = useContext(CookiesBannerContext);
-  const [privacyPath] = getPath(["/privacy-policy/"]);
-  const [cookiesPath] = getPath(["/cookies-policy/"]);
+  const privacyPath = getPath("/privacy-policy/", lang);
+  const cookiesPath = getPath("/cookies-policy/", lang);
   return (
     <footer>
       <div class="container f_container" id="contact">

--- a/src/entry.ssr.tsx
+++ b/src/entry.ssr.tsx
@@ -1,27 +1,32 @@
-/**
- * WHAT IS THIS FILE?
- *
- * SSR entry point, in all cases the application is rendered outside the browser, this
- * entry point will be the common one.
- *
- * - Server (express, cloudflare...)
- * - npm run start
- * - npm run preview
- * - npm run build
- *
- */
+import { isDev } from "@builder.io/qwik/build";
 import {
   renderToStream,
+  type RenderOptions,
   type RenderToStreamOptions,
 } from "@builder.io/qwik/server";
+import { config } from "./speak-config";
 import Root from "./root";
+
+/**
+ * Determine the base URL to use for loading the chunks in the browser.
+ * The value set through Qwik 'locale()' in 'plugin.ts' is saved by Qwik in 'serverData.locale' directly.
+ * Make sure the locale is among the 'supportedLocales'
+ */
+export function extractBase({ serverData }: RenderOptions): string {
+  if (!isDev && serverData?.locale) {
+    return "/build/" + serverData.locale;
+  } else {
+    return "/build";
+  }
+}
 
 export default function (opts: RenderToStreamOptions) {
   return renderToStream(<Root />, {
+    base: extractBase(opts),
     ...opts,
     // Use container attributes to set attributes on the html tag.
     containerAttributes: {
-      lang: "en-us",
+      lang: opts.serverData?.locale || config.defaultLocale.lang,
       ...opts.containerAttributes,
     },
     serverData: {

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -1,7 +1,18 @@
 import { $, component$, Slot, useContextProvider, useSignal } from "@builder.io/qwik";
+import { RequestHandler } from "@builder.io/qwik-city";
+import { localizePath } from "qwik-speak";
 import { ModalLetsWork } from "~/components/lets-work/LetsWork";
 import { MobileMenuContext } from "~/components/mobile-menu/MobileMenu";
-
+export const onRequest: RequestHandler = ({ locale, error, redirect }) => {
+  // E.g. 404 error page
+  // if (!locale()) throw error(404, "Page not found for requested locale");
+  console.error(error);
+  // E.g. Redirect
+  if (!locale()) {
+    const getPath = localizePath();
+    throw redirect(302, getPath("/", "en-EU")); // Let the server know the language to use
+  }
+};
 export default component$(() => {
   const isMenuOpen = useSignal<boolean>(false);
   const toggleMenu = $(() => {

--- a/src/routes/plugin.ts
+++ b/src/routes/plugin.ts
@@ -8,7 +8,7 @@ import { config } from "../speak-config";
  * because it is invoked on every request to the server.
  * Avoid redirecting or throwing errors here, and prefer layouts or pages
  */
-export const onRequest: RequestHandler = ({ params, error, locale }) => {
+export const onRequest: RequestHandler = ({ params, locale }) => {
   let lang: string | undefined = undefined;
 
   if (params.lang && validateLocale(params.lang)) {
@@ -23,12 +23,4 @@ export const onRequest: RequestHandler = ({ params, error, locale }) => {
 
   // Set Qwik locale
   locale(lang);
-
-  if (!locale()) throw error(404, "Page not found for requested locale");
-
-  // E.g. Redirect
-  // if (!locale()) {
-  //   const getPath = localizePath();
-  //   throw redirect(302, getPath('/page', 'en-US')); // Let the server know the language to use
-  // }
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,8 @@
  */
 import { defineConfig, type UserConfig } from "vite";
 import { qwikVite } from "@builder.io/qwik/optimizer";
-import { qwikCity } from "@builder.io/qwik-city/vite";
+import { qwikCity } from "@builder.io/qwik-city/vite";import { qwikSpeakInline } from 'qwik-speak/inline';
+
 import tsconfigPaths from "vite-tsconfig-paths";
 import pkg from "./package.json";
 
@@ -21,7 +22,11 @@ errorOnDuplicatesPkgDeps(devDependencies, dependencies);
  */
 export default defineConfig(({ command, mode }): UserConfig => {
   return {
-    plugins: [qwikCity(), qwikVite(), tsconfigPaths({ root: "." })],
+    plugins: [qwikCity(), qwikVite(), qwikSpeakInline({
+        supportedLangs: ['en-EU', 'it-IT', 'uk-UA'],
+        defaultLang: 'en-EU',
+        assetsPath: 'i18n'
+      }), tsconfigPaths({ root: "." })],
     // This tells Vite which dependencies to pre-build in dev mode.
     optimizeDeps: {
       // Put problematic deps that break bundling here, mostly those with binaries.


### PR DESCRIPTION
Make routing and UI locale-aware across the app: use useSpeakLocale and pass lang to localizePath where needed (logo, nav, cookies banner, footer) so generated paths include the current locale. Update NavList to compute lang from the current path, use translation helper tr for locale-specific labels, and wire onClick$ handlers (temporary console logging present). Adjust ChangeLocale text and button layout for concise rendering. Update SSR entry to set <html lang> from serverData.locale and compute base asset path via extractBase so client bundles load per-locale. Refine request handlers: layout now redirects to default locale when none provided, and plugin onRequest simplified to only set the Qwik locale. Add qwik-speak inline plugin to vite.config with supported languages and assets path for build-time i18n processing.